### PR TITLE
[#97] bugfix: 실시간 채팅 - 채팅 내역 정상적으로 표시

### DIFF
--- a/frontend-set/src/components/chat/ChatComponent.vue
+++ b/frontend-set/src/components/chat/ChatComponent.vue
@@ -102,14 +102,20 @@ const loadHistory = async () => {
             },
         })
         messages.value = res.data.map((msg) => {
+            // const chatResponse = JSON.parse(msg.body)
+            console.log('✅ msg:', msg)
+            const chatResponse = msg
+
             const now = new Date(msg.timestamp) // Assuming msg.timestamp is available from backend
             const hours = String(now.getHours()).padStart(2, '0')
             const minutes = String(now.getMinutes()).padStart(2, '0')
             const currentTime = `${hours}:${minutes}`
             return {
-                ...msg,
-                author: msg.sender, // UI 표시용
-                time: currentTime, // UI 표시용
+                id: chatResponse.id,
+                content: chatResponse.content,
+                isSelf: chatResponse.userId === authStore.loadUserId(),
+                author: chatResponse.username, // UI 표시용
+                time: chatResponse.timestamp, // UI 표시용
             }
         })
         console.log('불러온 메시지:', messages.value)
@@ -132,19 +138,24 @@ const connectWebSocket = () => {
         () => {
             console.log('✅ 연결 성공')
             stompClient.value.subscribe(`/topic/chat/${props.roomId}`, (msg) => {
-                const chatMessage = JSON.parse(msg.body)
-                const now = new Date()
-                const hours = String(now.getHours()).padStart(2, '0')
-                const minutes = String(now.getMinutes()).padStart(2, '0')
-                const currentTime = `${hours}:${minutes}`
+                const chatResponse = JSON.parse(msg.body)
+
+                console.log('✅ 메시지 수신:', chatResponse)
+
+                // const now = new Date()
+                // const now = chatResponse.timestamp
+                // const hours = String(now.getHours()).padStart(2, '0')
+                // const minutes = String(now.getMinutes()).padStart(2, '0')
+                // const currentTime = `${hours}:${minutes}`
 
                 const processedMessage = {
-                    ...chatMessage,
-                    isSelf: chatMessage.sender === mySenderId.value,
-                    author: chatMessage.sender, // UI 표시용
-                    time: currentTime, // UI 표시용
+                    id: chatResponse.id,
+                    content: chatResponse.content,
+                    isSelf: chatResponse.userId === authStore.loadUserId(),
+                    author: chatResponse.username, // UI 표시용
+                    time: chatResponse.timestamp, // UI 표시용
                 }
-                // messages.value.push(processedMessage)
+                messages.value.push(processedMessage)
             })
         },
         (error) => {
@@ -186,15 +197,15 @@ const sendMessage = () => {
         }
 
         // 1. 메시지 전송
-        stompClient.value.send(`/app/chat/${props.roomId}`, {}, JSON.stringify(chatMessage))
+        stompClient.value.send(`/app/chat/${props.roomId}`, {}, inputMessage.value.trim())
 
         // 2. 메시지 화면에 반영
-        messages.value.push({
-            ...chatMessage,
-            isSelf: true,
-            author: mySenderId.value,
-            time: currentTime,
-        })
+        // messages.value.push({
+        //     ...chatMessage,
+        //     isSelf: true,
+        //     author: mySenderId.value,
+        //     time: currentTime,
+        // })
 
         // 3. 입력창 비우기
         inputMessage.value = ''

--- a/frontend-set/src/pages/auth/LoginPage.vue
+++ b/frontend-set/src/pages/auth/LoginPage.vue
@@ -177,6 +177,7 @@ const handleLogin = async () => {
 
                 console.log('여기부터 안나옴')
                 console.log('✅authStore token:', authStore.loadToken())
+                console.log('✅authStore userId:', authStore.loadUserId())
                 console.log('✅authStore role:', authStore.loadRole())
             })
 

--- a/frontend-set/src/stores/auth.js
+++ b/frontend-set/src/stores/auth.js
@@ -4,7 +4,7 @@ import { defineStore } from 'pinia'
 export const useAuthStore = defineStore('auth', () => {
     const isLoggedIn = ref(false)
     const token = ref('')
-    const userRole = ref('')
+    const role = ref('')
     const userId = ref(null)
 
     function login(receivedAuthData) {
@@ -15,16 +15,13 @@ export const useAuthStore = defineStore('auth', () => {
         token.value = receivedAuthData.token
         console.log('✅token:', receivedAuthData.token)
 
-        userRole.value = receivedAuthData.userRole
+        role.value = receivedAuthData.userRole
         console.log('✅userRole:', receivedAuthData.userRole)
 
-        // userId가 있으면 저장
-        if (receivedAuthData.user && receivedAuthData.user.userId) {
-            userId.value = receivedAuthData.user.userId
-            localStorage.setItem('userId', receivedAuthData.user.userId)
-            console.log('✅userId:', receivedAuthData.user.userId)
-        }
+        userId.value = receivedAuthData.userId
+        console.log('✅userId:', receivedAuthData.userId)
 
+        localStorage.setItem('userId', receivedAuthData.userId.toString())
         localStorage.setItem('jwt', receivedAuthData.token)
         localStorage.setItem('role', receivedAuthData.userRole)
     }
@@ -32,7 +29,7 @@ export const useAuthStore = defineStore('auth', () => {
     function logout() {
         isLoggedIn.value = false
         token.value = ''
-        userRole.value = ''
+        role.value = ''
         userId.value = null
 
         // 모든 사용자 관련 localStorage 데이터 정리
@@ -61,9 +58,9 @@ export const useAuthStore = defineStore('auth', () => {
     function loadRole() {
         const savedRole = localStorage.getItem('role')
         if (savedRole) {
-            userRole.value = savedRole
+            role.value = savedRole
         }
-        return userRole.value
+        return role.value
     }
 
     function loadUserId() {
@@ -71,17 +68,17 @@ export const useAuthStore = defineStore('auth', () => {
         if (savedUserId) {
             userId.value = parseInt(savedUserId)
         }
-        return userId
+        return userId.value
     }
 
     function isFinanceRole() {
-        return userRole.value === 'ROLE_FINANCE'
+        return role.value === 'ROLE_FINANCE'
     }
 
     return {
         isLoggedIn,
         token,
-        userRole,
+        userRole: role,
         userId,
         login,
         logout,


### PR DESCRIPTION
## 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 코드에 영향을 주지 않는 변경사항 (ex. 오타 수정, 탭 사이즈 변경, 변수명 변경)

## 📌 이슈 번호
close #97

## ✨ 반영 브랜치
bugfix#97-chatting -> develop

## ✅ 수정 사항
- 채팅치면 실시간으로 전달
- 채팅 보낸 사람 이름 (username) 표시
- 채팅 내역 DB 저장
- 자신이 보낸 채팅은 파란색, 다른 사람이 보낸 채팅은 회색으로 표시
- 채팅 보내고 새로고침 안해도 됨
- 채팅 보내고 내 메시지가 파란색, 회색 각각 하나씩 총 2번 뜨지 않음

- authStore에 userId를 함께 저장하도록 수정
- 자신이 보낸 메시지를 판별하기 위해 authStore에 저장된 userId (현재 로그인된 사용자 id) 와 api로 불러온 채팅의 userId (채팅을 쓴 사용자 id)를 비교하도록 수정

## 🙏 리뷰 요청 사항
<!-- 리뷰어에게 요청하고 싶은 부분을 작성해주세요 -->
