### PR TITLE
fix: 첼린지 bug fix + modal 기능 구현

### DIFF
--- a/frontend-set/src/api/challengeAdminApi.js
+++ b/frontend-set/src/api/challengeAdminApi.js
@@ -1,15 +1,16 @@
 import axios from 'axios'
+import api from '.'
 
 // 챌린지 참여자 목록 조회
 export const getChallengeParticipants = (fundId, token) => {
-    return axios.get(`/admin/challenge/${fundId}/participants`, {
+    return api.get(`/admin/challenge/${fundId}/participants`, {
         headers: { Authorization: `Bearer ${token}` },
     })
 }
 
 // 특정 참여자의 인증 기록 조회 (+상태 필터링)
 export const getParticipantLogs = (userChallengeId, status, token) => {
-    return axios.get(`/admin/challenge/logs/${userChallengeId}`, {
+    return api.get(`/admin/challenge/logs/${userChallengeId}`, {
         params: { status: status === 'ALL' ? null : status },
         headers: { Authorization: `Bearer ${token}` },
     })
@@ -17,7 +18,7 @@ export const getParticipantLogs = (userChallengeId, status, token) => {
 
 // 인증 기록 수동 승인
 export const manuallyApproveLog = (logId, token) => {
-    return axios.patch(
+    return api.patch(
         `/admin/challenge/logs/${logId}/approve`,
         {},
         {

--- a/frontend-set/src/api/fundApi.js
+++ b/frontend-set/src/api/fundApi.js
@@ -1,11 +1,12 @@
 import axios from 'axios'
+import api from '.'
 
 /**
  * 내가 생성한 '대출(Loan)' 타입 펀딩 목록 조회
  * @param {string} token - 인증 토큰
  */
 export const getMyCreatedLoans = (token) => {
-    return axios.get('/fund/my/fund/all?fundType=Loan', {
+    return api.get('/fund/my/fund/all?fundType=Loan', {
         headers: {
             Authorization: `Bearer ${token}`,
         },
@@ -18,7 +19,7 @@ export const getMyCreatedLoans = (token) => {
  */
 export const getMyCreatedChallenges = (token) => {
     // 기존 API를 재활용하여 fundType으로 필터링
-    return axios.get('/fund/my/fund/all?fundType=Challenge', {
+    return api.get('/fund/my/fund/all?fundType=Challenge', {
         headers: {
             Authorization: `Bearer ${token}`,
         },

--- a/frontend-set/src/components/common/AlertModal.vue
+++ b/frontend-set/src/components/common/AlertModal.vue
@@ -1,0 +1,57 @@
+<template>
+    <div
+        v-if="show"
+        class="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center"
+        @click.self="$emit('close')"
+    >
+        <div
+            class="bg-white rounded-xl shadow-2xl p-6 w-full max-w-sm text-center transform transition-all"
+        >
+            <div
+                class="mx-auto flex items-center justify-center h-12 w-12 rounded-full mb-4"
+                :class="iconBgClass"
+            >
+                <i class="fas text-2xl text-white" :class="iconClass"></i>
+            </div>
+
+            <h3 class="text-lg font-medium leading-6 text-gray-900 mb-2">{{ title }}</h3>
+
+            <div class="text-sm text-gray-500 mb-6">
+                <p>{{ message }}</p>
+            </div>
+
+            <button
+                @click="$emit('close')"
+                class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white focus:outline-none sm:text-sm"
+                :class="buttonClass"
+            >
+                확인
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// @param {boolean} show - 모달 표시 여부
+// @param {string} type - 'success' 또는 'error'
+// @param {string} title - 모달 제목
+// @param {string} message - 모달 메시지
+const props = defineProps({
+    show: Boolean,
+    type: { type: String, default: 'success' },
+    title: String,
+    message: String,
+})
+
+defineEmits(['close'])
+
+const isSuccess = computed(() => props.type === 'success')
+
+const iconBgClass = computed(() => (isSuccess.value ? 'bg-green-500' : 'bg-red-500'))
+const iconClass = computed(() => (isSuccess.value ? 'fa-check' : 'fa-times'))
+const buttonClass = computed(() =>
+    isSuccess.value ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700',
+)
+</script>


### PR DESCRIPTION
📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
[x] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[x] 코드 리팩토링

📌 이슈 번호
close #145 

✨ 반영 브랜치
fix#145-challenge-admin-fix -> develop

🙏 리뷰 요청 사항
안녕하세요! 챌린지 생성자가 참여자 목록을 확인하고, AI가 판별하지 못한 인증 기록을 수동으로 검증하는 전체 UI 플로우를 구현했습니다.

📝 주요 기능 및 페이지
내 챌린지 목록 페이지 (/admin/my-challenges)
관리자가 자신이 생성한 '챌린지' 타입의 상품만 모아서 볼 수 있는 페이지입니다.
각 챌린지 카드를 클릭하면 아래의 '참여자 목록 페이지'로 이동합니다.

챌린지 참여자 목록 페이지 (/admin/challenge/:fundId/participants)
특정 챌린지에 참여한 유저 목록을 테이블 형태로 보여줍니다.
각 참여자의 이름이 해당 참여자의 '인증 기록 검증 페이지'로 이동하는 링크 역할을 하여 직관적인 UX를 제공합니다.

인증 기록 검증 페이지 (/admin/challenge/logs/:userChallengeId)
특정 참여자의 모든 인증 기록을 카드 형태로 조회하고 관리하는 핵심 페이지입니다.
상태별 필터링 탭: '수동 검증 필요', '검증 완료' 등 상태별로 인증 기록을 필터링할 수 있습니다.

수동 검증 기능: HumanVerify 상태의 기록에 대해 '승인' 또는 '반려' 버튼이 나타나며, 클릭 시 API를 호출하고 성공하면 새로고침 없이도 화면이 즉시 갱신됩니다.

✨ 사용자 경험(UX) 개선
확인/알림 모달 적용: 기존에 사용하던 브라우저 기본 confirm()과 alert() 창을 모두 재사용 가능한 커스텀 모달 컴포넌트(ConfirmationModal, AlertModal)로 교체했습니다. 이를 통해 일관성 있는 디자인과 더 나은 사용자 경험을 제공합니다.
